### PR TITLE
fix: resolve production notion api connection and add dynamic port su…

### DIFF
--- a/scripts/notion-proxy.js
+++ b/scripts/notion-proxy.js
@@ -56,7 +56,7 @@ app.get('/api/projects', async (req, res) => {
   }
 });
 
-const PORT = 3001;
-app.listen(PORT, () => {
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, '0.0.0.0', () => {
   console.log(`Proxy do Notion rodando na porta ${PORT}`);
 });

--- a/src/services/notion.js
+++ b/src/services/notion.js
@@ -29,8 +29,12 @@ const extractTags = (multiSelectArray) => {
 // Remove the direct Notion API check since we aren't using the secret in the browser anymore
 export const getProjectsFromNotion = async () => {
   try {
-    // Fetch from our local proxy
-    const response = await fetch('http://localhost:3001/api/projects');
+    // Busca a URL da API do ambiente ou usa fallback dinâmico
+    const API_URL = import.meta.env.VITE_API_URL || 
+                    (import.meta.env.PROD ? '/api/projects' : 'http://localhost:3001/api/projects');
+    
+    // Fetch from our local proxy or production endpoint
+    const response = await fetch(API_URL);
     
     if (!response.ok) {
       throw new Error(`HTTP error status: ${response.status}`);


### PR DESCRIPTION
This pull request improves the flexibility and environment compatibility of the Notion proxy and frontend service. The main changes make the backend listen on all interfaces and allow the frontend to dynamically select the correct API endpoint based on the environment.

Backend improvements:

* Updated the server to listen on all network interfaces (`'0.0.0.0'`) and to use the port specified in the `PORT` environment variable, defaulting to 3001 if not set.

Frontend improvements:

* Modified the API URL selection logic in `getProjectsFromNotion` to use the environment variable `VITE_API_URL`, or fallback to a dynamic endpoint depending on whether the app is running in production or development.