### PR TITLE
fix: resolve infinite project image loading issue with cache TTL and …

### DIFF
--- a/src/components/ProjectDetail.jsx
+++ b/src/components/ProjectDetail.jsx
@@ -37,6 +37,9 @@ const ProjectDetail = () => {
   const [relatedProjectImageErrors, setRelatedProjectImageErrors] = useState(
     {},
   );
+  
+  const mainImageRef = useRef(null);
+  const loadingTimeoutRef = useRef(null);
 
   const { projects, loading: projectsLoading, getProjectBySlug, getRelatedProjects } = useNotionProjects();
 
@@ -132,11 +135,42 @@ const ProjectDetail = () => {
   useEffect(() => {
     setImageLoaded(false);
     setImageError(false);
-  }, [currentImageIndex]);
+
+    // Se a imagem já estiver no cache do navegador, o evento onLoad pode não disparar em alguns casos
+    // ou disparar instantaneamente. Verificamos se já está completa.
+    const checkImageStatus = () => {
+      if (mainImageRef.current && mainImageRef.current.complete) {
+        if (mainImageRef.current.naturalWidth > 0) {
+          setImageLoaded(true);
+        } else {
+          setImageError(true);
+        }
+      }
+    };
+
+    // Pequeno delay para garantir que o src foi atualizado no DOM
+    const rafId = requestAnimationFrame(checkImageStatus);
+
+    // Safety timeout: se não carregar em 10 segundos, mostra erro/fallback
+    // para evitar o shimmer infinito
+    if (loadingTimeoutRef.current) clearTimeout(loadingTimeoutRef.current);
+    loadingTimeoutRef.current = setTimeout(() => {
+      if (!imageLoaded && !imageError) {
+        console.warn("Image load timeout reached");
+        setImageError(true);
+      }
+    }, 10000);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      if (loadingTimeoutRef.current) clearTimeout(loadingTimeoutRef.current);
+    };
+  }, [currentImageIndex, project?.images]);
 
   // Animação suave ao carregar imagem
   useEffect(() => {
     if (imageLoaded) {
+      if (loadingTimeoutRef.current) clearTimeout(loadingTimeoutRef.current);
       setIsTransitioning(false);
     }
   }, [imageLoaded]);
@@ -435,6 +469,7 @@ const ProjectDetail = () => {
                 {!imageError ? (
                   <img
                     key={`main-image-${currentImageIndex}`}
+                    ref={mainImageRef}
                     src={getImagePath(project.images[currentImageIndex])}
                     alt={`${project.title?.[i18n.language] || project.title?.pt} - ${project.images[currentImageIndex]
                       .split("/")
@@ -444,8 +479,12 @@ const ProjectDetail = () => {
                     className={`w-full h-auto max-h-[32rem] object-contain transition-all duration-700 ease-in-out z-0 ${
                       imageLoaded && !isTransitioning ? "opacity-100 scale-100" : "opacity-0 scale-95"
                     }`}
-                    onLoad={() => setImageLoaded(true)}
+                    onLoad={() => {
+                      if (loadingTimeoutRef.current) clearTimeout(loadingTimeoutRef.current);
+                      setImageLoaded(true);
+                    }}
                     onError={() => {
+                      if (loadingTimeoutRef.current) clearTimeout(loadingTimeoutRef.current);
                       setImageError(true);
                       setImageLoaded(false);
                     }}

--- a/src/hooks/useNotionProjects.js
+++ b/src/hooks/useNotionProjects.js
@@ -2,29 +2,47 @@ import { useState, useEffect, useCallback } from 'react';
 import { getProjectsFromNotion } from '../services/notion';
 
 const CACHE_KEY = 'notion_projects_cache';
+const CACHE_TIMESTAMP_KEY = 'notion_projects_cache_timestamp';
+const CACHE_TTL = 50 * 60 * 1000; // 50 minutos (Notion URLs expiram em 60 min)
 
 export const useNotionProjects = () => {
   // Inicializa o estado com o que estiver no LocalStorage para carregamento instantâneo
   const [projects, setProjects] = useState(() => {
     const cached = localStorage.getItem(CACHE_KEY);
-    return cached ? JSON.parse(cached) : [];
+    const timestamp = localStorage.getItem(CACHE_TIMESTAMP_KEY);
+    const now = Date.now();
+
+    if (cached && timestamp && (now - parseInt(timestamp) < CACHE_TTL)) {
+      return JSON.parse(cached);
+    }
+    return [];
   });
   
-  // Se já temos dados no cache, não precisamos mostrar o "loading" principal na entrada
+  // Se já temos dados no cache válidos, não precisamos mostrar o "loading" principal na entrada
   const [loading, setLoading] = useState(!projects.length);
   const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchProjects = async () => {
       try {
-        // Se não temos nada, liga o loading. Se temos cache, buscamos em background.
-        if (projects.length === 0) setLoading(true);
+        const cached = localStorage.getItem(CACHE_KEY);
+        const timestamp = localStorage.getItem(CACHE_TIMESTAMP_KEY);
+        const now = Date.now();
+        const isCacheValid = cached && timestamp && (now - parseInt(timestamp) < CACHE_TTL);
+
+        // Se o cache é válido e já carregamos dele no useState inicial, 
+        // podemos pular o fetch se quisermos economizar API, 
+        // mas aqui mantemos o fetch em background para garantir dados sempre frescos
+        if (!isCacheValid) {
+          if (projects.length === 0) setLoading(true);
+        }
         
         const data = await getProjectsFromNotion();
         setProjects(data);
         
-        // Salva no LocalStorage para a próxima visita
+        // Salva no LocalStorage com timestamp para a próxima visita
         localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+        localStorage.setItem(CACHE_TIMESTAMP_KEY, Date.now().toString());
       } catch (err) {
         console.error("Failed to load projects from Notion:", err);
         // Só mostra erro se não tivermos nada no cache para exibir


### PR DESCRIPTION
This pull request introduces improvements to image loading reliability and caching logic in the project detail and project fetching components. The main focus is to ensure images display correctly even when cached, prevent infinite loading states, and optimize project data caching to avoid unnecessary API calls.

**Image loading reliability improvements:**

* Added `mainImageRef` and `loadingTimeoutRef` to `ProjectDetail` for tracking image element and loading timeout.
* Enhanced image loading logic: checks if image is already loaded (via cache), adds a safety timeout to prevent infinite shimmer, and clears timeout on load/error.
* Passed `mainImageRef` to the main image element and updated `onLoad`/`onError` handlers to clear timeout and update state appropriately. [[1]](diffhunk://#diff-5aa570964fcc1ae928aed796f3b6b4cdcbc5210d84011b381aedb45257e3877dR472) [[2]](diffhunk://#diff-5aa570964fcc1ae928aed796f3b6b4cdcbc5210d84011b381aedb45257e3877dL447-R487)

**Project data caching improvements:**

* Introduced cache TTL (50 minutes) and timestamp keys in `useNotionProjects`, so cached project data is considered valid only within the TTL, preventing stale Notion URLs.
* Updated logic to load from cache only if valid, and always fetch fresh data in the background to keep projects up-to-date, saving new data and timestamp after fetch.…safety timeout